### PR TITLE
Fix planet maps saving

### DIFF
--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -87,7 +87,34 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         Subs.CVar(_configManager, CVars.NetMaxUpdateRange, SetLoadRange, true);
         InitializeCommands();
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(ProtoReload);
+        SubscribeLocalEvent<TransformComponent, EntityTerminatingEvent>(OnEntityRemove); // Exodus-MapSavingFix
     }
+
+    // Exodus-MapSavingFix-Start
+    private void OnEntityRemove(EntityUid uid, TransformComponent transform, ref EntityTerminatingEvent ev)
+    {
+        // this is needed for clearing entities from BiomeComponent.LoadedEntities when they're getting deleted or else the biome cannot be saved
+        // this is happens due to transforming of EntityUid to the zero (or invalid entityuid in other words) which creates key duplicates in dictionary
+        // cuz of that serializer crashes
+
+        // is entity on biome
+        if (!_biomeQuery.TryGetComponent(transform.MapUid, out var biome))
+            return;
+
+        // is map initialized, if it is - we have nothing to do here
+        if (TryComp<MapComponent>(transform.MapUid, out var map) && map.MapInitialized)
+        {
+            return;
+        }
+
+        var cords = _transform.GetWorldPosition(transform);
+        var vector = new Vector2i((int) Math.Floor(cords.X / 8) * 8, (int) Math.Floor(cords.Y / 8) * 8);
+
+        biome.LoadedEntities.TryGetValue(vector, out var entities);
+        DebugTools.Assert(entities is not null, $"Cannot get chunk for entity {ev.Entity}");
+        entities.Remove(ev.Entity);
+    }
+    // Exodus-MapSavingFix-End
 
     private void ProtoReload(PrototypesReloadedEventArgs obj)
     {


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
Чтож, у нас была длительное время такая проблема: Планеты на которых что-то маппят очень не хотят сохраняться. 
Я провёл расследование этой проблемы. Сама ошибка возникала именно при удалении двух сущностей, которые были сгенерированы биомом в одном чанке. А возникала она из-за того, что BiomeComponent (компонент карты) имеет у себя такое свойство: LoadedEntities. Это свойство, в котором хранятся по чанкам все сущности, которые были сгенерированы биомом. И выглядит этот тип так: `Dictionary<Vector2i, Dictionary<EntityUid, Vector2i>>`. Проблема была в том, что при удалении экземпляр EntityUid получал один и тот же ключ равный нулю. Иными словами это Invalid EntityUid. И из-за того, что у нас происходил дубликат невалидного EntityUid как ключа словаря - происходила ошибка при сериализации карты.

Пофиксил это всё, собственно говоря, используя событие предшествующее удалению сущности EntityTerminationEvent в котором из TransformComponent получал нужный чанк и удалял сущность из LoadedEntities. После этого проблема решилась.

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->
https://github.com/Space-Exodus/space-station-14/assets/60302610/c7e79f69-1db5-4910-a7a1-e743ee06c27d

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl:
- fix: Исправлено сохранение карт с планетами!
