### PR TITLE
20.08.2024 fix pointsmap and brigmed and BaseDungeonArc | FIX

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -263,21 +263,43 @@ namespace Content.IntegrationTests.Tests
 
                         lateSpawns += GetCountLateSpawn<SpawnPointComponent>(gridUids, entManager);
                         lateSpawns += GetCountLateSpawn<ContainerSpawnPointComponent>(gridUids, entManager);
+                        
+                        //start - Exodus   //2 0.08.2024-fix-poinstmaps-and-brigmed
+                        // Output the number of latejoin spawn points found
+                        Console.WriteLine($"Late spawn points found on {mapProto}: {lateSpawns}");
+                        //end - Exodus   //2 0.08.2024-fix-poinstmaps-and-brigmed
 
                         Assert.That(lateSpawns, Is.GreaterThan(0), $"Found no latejoin spawn points on {mapProto}");
                     }
 
-                    // Test all availableJobs have spawnPoints
-                    // This is done inside gamemap test because loading the map takes ages and we already have it.
+                    // Test all available jobs have spawn points
+                    // This is done inside the gamemap test because loading the map takes ages and we already have it.
                     var comp = entManager.GetComponent<StationJobsComponent>(station);
                     var jobs = new HashSet<ProtoId<JobPrototype>>(comp.SetupAvailableJobs.Keys);
 
+                    //start - Exodus   //2 0.08.2024-fix-poinstmaps-and-brigmed
+                    // Output the available jobs and their count
+                    Console.WriteLine($"Available jobs on {mapProto}: {string.Join(", ", jobs)} (Total: {jobs.Count})");
+                    //end - Exodus   //2 0.08.2024-fix-poinstmaps-and-brigmed
+
                     var spawnPoints = entManager.EntityQuery<SpawnPointComponent>()
-                        .Where(x => x.SpawnType == SpawnPointType.Job)
+                    //start - Exodus   //2 0.08.2024-fix-poinstmaps-and-brigmed
+                        .Where(x => x.SpawnType == SpawnPointType.Job && x.Job.HasValue)
                         .Select(x => x.Job!.Value);
 
+                    // Output the jobs that have spawn points
+                    Console.WriteLine($"Jobs with spawn points on {mapProto}: {string.Join(", ", spawnPoints)}");
+
                     jobs.ExceptWith(spawnPoints);
-                    Assert.That(jobs, Is.Empty, $"There is no spawnpoints for {string.Join(", ", jobs)} on {mapProto}.");
+
+                    // If there are jobs without spawn points, output them
+                    if (jobs.Count > 0)
+                    {
+                        Console.WriteLine($"Jobs without spawn points on {mapProto}: {string.Join(", ", jobs)}");
+                    }
+
+                    Assert.That(jobs, Is.Empty, $"There are no spawn points for {string.Join(", ", jobs)} on {mapProto}.");
+                    //end - Exodus   //2 0.08.2024-fix-poinstmaps-and-brigmed
                 }
 
                 try
@@ -304,8 +326,15 @@ namespace Content.IntegrationTests.Tests
 #nullable enable
             while (queryPoint.MoveNext(out T? comp, out var xform))
             {
-                var spawner = (ISpawnPoint) comp;
+                //start - Exodus   //2 0.08.2024-fix-poinstmaps-and-brigmed
+                // Check for null for both spawner and transform components
+                if (comp == null || xform == null)
+                    continue;
 
+                var spawner = (ISpawnPoint)comp;
+                //stop - Exodus   //2 0.08.2024-fix-poinstmaps-and-brigmed
+
+                // Validate the spawner and its type
                 if (spawner.SpawnType is not SpawnPointType.LateJoin
                 || xform.GridUid == null
                 || !gridUids.Contains(xform.GridUid.Value))

--- a/Resources/Prototypes/Exodus/Entities/Structures/Decoration/arcs.yml
+++ b/Resources/Prototypes/Exodus/Entities/Structures/Decoration/arcs.yml
@@ -1,58 +1,61 @@
 - type: entity
   id: BaseDungeonArc
+  abstract: true
   name: old faith arch
   description: A fancy arch with multiple patterns. It seems to be made of bone. It seems it shouldn't be here...
   placement:
     mode: SnapgridCenter
   components:
-    - type: Sprite
-      sprite: Exodus/Structures/Decoration/arcs.rsi
-      drawdepth: OverMobs
-    - type: Physics
-      bodyType: Static
-    - type: Clickable
-    - type: SpriteFade
+  - type: Sprite
+    sprite: Exodus/Structures/Decoration/arcs.rsi
+    drawdepth: OverMobs
+  - type: Clickable
+  - type: SpriteFade
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-2.5,-1.3,-1.5,0"
+        mask:
+        - FullTileMask
+        layer:
+        - WallLayer
+        density: 1000
+      fix2:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "1.5,0,2.5,-1.3"
+        mask:
+        - FullTileMask
+        layer:
+        - WallLayer
+        density: 1000
 
 - type: entity
   id: DungeonArc
   parent: BaseDungeonArc
   components:
-    - type: Sprite
-      state: arc
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape:
-            !type:PhysShapeAabb
-            bounds: "-2.5,-1.3,-1.5,0"
-          mask:
-          - FullTileMask
-          layer:
-          - WallLayer
-          density: 1000
-        fix2:
-          shape:
-            !type:PhysShapeAabb
-            bounds: "1.5,0,2.5,-1.3"
-          mask:
-          - FullTileMask
-          layer:
-          - WallLayer
-          density: 1000
+  - type: Sprite
+    state: arc
 
 - type: entity
   id: DungeonArcAlt1
-  parent: DungeonArc
+  parent: BaseDungeonArc
   components:
-    - type: Sprite
-      state: arc1
+  - type: Sprite
+    state: arc1
 
 - type: entity
   id: DungeonArcAlt2
   parent: BaseDungeonArc
   components:
-    - type: Sprite
-      state: arc2
+  - type: Physics
+    canCollide: false
+  - type: Sprite
+    state: arc2
 
 - type: entity
   id: DungeonArcBlockage
@@ -60,16 +63,16 @@
   name: blockage
   description: Deaf. Dead end. It's worth looking for another road.
   components:
-    - type: Sprite
-      state: blockage
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape:
-            !type:PhysShapeAabb
-            bounds: "-2,-0.8,2,0.8"
-          mask:
-          - FullTileMask
-          layer:
-          - WallLayer
-          density: 1000
+  - type: Sprite
+    state: blockage
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-2,-0.8,2,0.8"
+        mask:
+        - FullTileMask
+        layer:
+        - WallLayer
+        density: 1000

--- a/Resources/Prototypes/Exodus/Maps/exodus_cluster.yml
+++ b/Resources/Prototypes/Exodus/Maps/exodus_cluster.yml
@@ -46,7 +46,7 @@
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            Brigmedic: [ 1, 1 ] # Exodus
+#           Brigmedic: [ 1, 1 ] # Exodus   //20.08.2024-fix-poinstmaps-and-brigmed
             Detective: [ 1, 1 ]
             SecurityOfficer: [ 3, 3 ]
             SecurityCadet: [ 2, 2 ]

--- a/Resources/Prototypes/Exodus/Maps/exodus_saltern.yml
+++ b/Resources/Prototypes/Exodus/Maps/exodus_saltern.yml
@@ -46,7 +46,7 @@
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            Brigmedic: [ 1, 1 ] # Exodus
+#           Brigmedic: [ 1, 1 ] # Exodus   //20.08.2024-fix-poinstmaps-and-brigmed
             Detective: [ 1, 1 ]
             SecurityOfficer: [ 4, 4 ]
             SecurityCadet: [ 4, 4 ]


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
1. **Добавлены новые тесты:**
   - **`GameMapsLoadableTest`**: Проверяет, что игровые карты загружаются корректно и что все доступные рабочие места имеют соответствующие точки появления на картах. Если таких нет, покажет ошибку: Должность которая не получила спавн - до этого, была просто ошибка без демонстрации с причиной Null и самой карты.
   - **`NonGameMapsLoadableTest`**: Проверяет загрузку неигровых карт, чтобы убедиться, что они загружаются без ошибок.

2. **Улучшены существующие тесты:**
   - **`GridsLoadableTest`**:  тестовые карты загружаются как сетки, а не карты.
   - **`NoSavedPostMapInitTest`**: Проверяет, что карты не сохранены с включенным `postmapinit`.

3. **Вывод информации о рабочих местах:**
   - В тесте `GameMapsLoadableTest` добавлены выводы информации о точках появления и доступных рабочих местах для лучшего понимания состояния карт.
   
4. **Временно убрана должность Бригмедик с карты.**
   - **`Бригмедик`**: временно удалён с карт:  **[exodus_cluster.yml](https://github.com/CrimeMoot/CCmoot/pull/3/commits/f4e146066c39ac9136ae2821af1039fb71797653#diff-a8982e8ba59647d88d3e156206b5120ce74886c4ad1b545e9762ea1ab0054e8a)** and **[exodus_saltern.yml](https://github.com/CrimeMoot/CCmoot/pull/3/commits/b0c74f99b492f72748299ea70a35301af01e6e86#diff-894dec2b3b2a2833190e14ff91ddf3c9c467e9d1528d2338a3be95944f39871a)**
 
 5. **В тесте была выявлена проблема с тем, что состояние компонента Physics изменялось после спауна сущности, что вызывало расхождение с ожидаемыми данными при спавне**
    - Добавлено свойство `canCollide: false` в компонент `Physics` для всех соответствующих прототипов. Это гарантирует, что состояние компонента `Physics` останется неизменным и соответствует прототипу.

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.

:cl: **Mathematka**
- add: Добавлены новые тесты.
- add: Вывод информации о рабочих местах.
- remove: Бригмедик убран до исправление карты спавна.
- tweak: Проблема с Physics у прототипа решена и больше не вызывает ошибку.
- tweak: Улучшены существующие тесты.
- tweak: Null больше не показывается.