### PR TITLE
Brigmedic fix

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
@@ -486,16 +486,6 @@
       - state: green
       - state: detective
 
-- type: entity
-  id: SpawnPointBrigmedic
-  parent: SpawnPointJobBase
-  name: brigmedic
-  components:
-  - type: Sprite
-    layers:
-      - state: green
-      - state: brigmedic
-
 # SPECIAL
 # ERT
 - type: entity

--- a/Resources/Prototypes/_Exodus/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/_Exodus/Entities/Markers/Spawners/jobs.yml
@@ -1,0 +1,13 @@
+# BrigMedic
+
+- type: entity
+  id: SpawnPointBrigmedic
+  parent: SpawnPointJobBase
+  name: brigmedic
+  components:
+  - type: SpawnPoint
+    job_id: Brigmedic
+  - type: Sprite
+    layers:
+      - state: green
+      - state: brigmedic

--- a/Resources/Prototypes/_Exodus/Maps/exodus_cluster.yml
+++ b/Resources/Prototypes/_Exodus/Maps/exodus_cluster.yml
@@ -46,7 +46,7 @@
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-#           Brigmedic: [ 1, 1 ] # Exodus   //20.08.2024-fix-poinstmaps-and-brigmed
+            Brigmedic: [ 1, 1 ] # Exodus
             Detective: [ 1, 1 ]
             SecurityOfficer: [ 3, 3 ]
             SecurityCadet: [ 2, 2 ]

--- a/Resources/Prototypes/_Exodus/Maps/exodus_saltern.yml
+++ b/Resources/Prototypes/_Exodus/Maps/exodus_saltern.yml
@@ -46,7 +46,7 @@
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-#           Brigmedic: [ 1, 1 ] # Exodus   //20.08.2024-fix-poinstmaps-and-brigmed
+            Brigmedic: [ 1, 1 ] # Exodus
             Detective: [ 1, 1 ]
             SecurityOfficer: [ 4, 4 ]
             SecurityCadet: [ 4, 4 ]

--- a/Resources/Prototypes/_Exodus/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_Exodus/Roles/Jobs/Security/brigmedic.yml
@@ -1,7 +1,7 @@
 - type: job
   id: Brigmedic
   name: job-name-brigmedic
-  description: job-description-chemist
+  description: job-description-brigmedic
   playTimeTracker: JobBrigmedic
   requirements:
     - !type:DepartmentTimeRequirement


### PR DESCRIPTION
## Описание PR
Небольшие исправления бригмедика и его возвращение на 2 карты Exodus'а. 

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
Исправлен SpawnPointBrigmedic, также исправлено описание должности бригмедика и он возвращен на ExodusSaltern и ExodusCluster.

:cl:
- fix: Исправлена точка появления бриг медика и его описание. В связи с исправлением точки появления бригмедик возвращен на карты.

