### PR TITLE
Update licenses

### DIFF
--- a/CLA.txt
+++ b/CLA.txt
@@ -34,7 +34,7 @@ license for the entire period of validity of the Contributor's rights to the Con
 for by the legislation of the state-jurisdiction of the Contributor
 and/or international legislation for certain forms of Contribution.
 Licensor – Space Exodus. Authorized representative of the Licensor on the issue of granting
-permits, legal and technical issues – Maksim Bychkov (lokilife0002@gmail.com).
+permits, legal and technical issues – Maksim Bychkov (maxim@bychkov.tech).
 
 The scope of the rights granted.
 

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,23 +1,57 @@
-MIT License
+Preamble
+Upon receipt of a copy of the license object by any means, any person can use it if he
+accepts and agrees to all the terms of this license. Violation of the license terms grants us
+(the Licensor) the right to apply methods of legal and technological protection using the
+DMCA and/or other legislation of the states under whose jurisdiction hosting providers
+and other information intermediaries are located, providing services to violators of the
+terms of this license. Acceptance of the terms of this license means a definitive conclusion
+between you and Space Exodus of a gratuitous simple non–exclusive license, hereinafter referred
+to as the "Agreement". The Agreement does not include provisions regulating issues
+related to the processing of personal data.
 
-Copyright (c) 2017-2025 Space Wizards Federation
-Copyright (c) 2021-2025 Corvax
-Copyright (c) 2025 Space Exodus Team
+Definitions.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+A build is an object of Agreement, the result of the original author's work of a team of
+authors (hereinafter referred to as the "Company"), a complex intellectual property object
+– a video game that including, but not limited to, source, object code, tools, game assets,
+specifications, UI/UX design, elements of narrative and other creative character based on
+the revision and translation into Russian of the open version of Space Station 14 and the
+artistic vision of the authors. The set of individual elements is a Build. Any elements other
+than the original elements are objects of copyright and/or related rights created by the
+creative work of the collective.
+Contribution – means any original author's work of Contributors, including any
+modifications or additions to the Build (any source code, object code, correction, tool,
+sample, graphics, assets, specifications, manuals, documentation), which is intentionally
+provided from the Licensee to the Licensor. For the purposes of this definition,
+submission means any form of electronic, oral or written communication sent to Licensor
+or its representatives, including, but not limited to, messages on electronic mailing lists,
+source code control systems and issue tracking systems operated by or on behalf of the
+Company for the purposes of discussing or improving software or project documentation
+and soder. Communications for which it is explicitly stated in writing as "Not a
+contribution" will not be considered a contribution. When providing a Contribution to the
+Build, the Contributor provides the Company with a simple, free, irrevocable, non-exclusive
+license for the entire period of validity of the Contributor's rights to the Contribution provided
+for by the legislation of the state-jurisdiction of the Contributor
+and/or international legislation for certain forms of Contribution.
+Licensor – Space Exodus. Authorized representative of the Licensor on the issue of granting
+permits, legal and technical issues – Maksim Bychkov (maxim@bychkov.tech).
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The scope of the rights granted.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+The license grants an unlimited number of persons the right to copy and make changes
+solely for the purpose of improving the game and subject to the further transfer of such
+changes to Space Exodus on the terms of the Contribution, as well as for non-public hosting and
+launching the Build on the Licensee's computer for the purpose of non-commercial use
+for its intended purpose (providing access to Players and the Game process). This license
+expressly prohibits commercial use, public hosting, as well as non-licensed use. The use
+of the Build or its elements in violation of the terms of this License grants the Licensor
+the right to contact the hosting provider and other persons - information intermediaries
+to block hosting. The Licensee can carry out public hosting of the Build only if he receives
+direct permission from the Licensor.
+
+A reservation about the types of licenses.
+
+Individual elements of the Build (graphics, sounds, source code) may be distributed under
+a license other than this one. Most assets are licensed under CC-BY-SA 3.0 unless
+otherwise specified. Assets have their own license and copyright in the metadata file. If
+the license type is not specified, such files are distributed under the terms of this license.

--- a/MIT_LICENSE.TXT
+++ b/MIT_LICENSE.TXT
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2017-2025 Space Wizards Federation
+Copyright (c) 2021-2025 Corvax
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Описание PR
Обновление лицензии.
Основная лицензия репозитория была перемещена в LICENSE.TXT для того, чтобы Github лучше понимал и отображал какой именно лицензией мы пользуемся. Лицензия Space Wizards и Corvax была перемещена в MIT_LICENSE.TXT, сохраняя юридическую корректность.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Space Exodus CLA](https://github.com/space-exodus/space-station-14/blob/master/CLA.txt) и соглашаюсь с её условиями.

**Список изменений**
No CL