### PR TITLE
Role Species Blaclist

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -555,6 +555,10 @@
 
 - type: randomHumanoidSettings
   id: CentcomOfficial
+  # Exodus-CentCom-Lore-Start
+  speciesBlacklist:
+    - Vox
+  # Exodus-CentCom-Lore-End
   parent: EventHumanoidMindShielded
   components:
     - type: GhostRole

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -14,14 +14,6 @@
     - type: MindShield
     - type: AntagImmune
 
-- type: randomHumanoidSettings
-  id: EventHumanoidCentcomm
-  parent: EventHumanoidMindShielded
-  components:
-  - type: AutoImplant
-    implants:
-    - DeathRattleImplantCentcomm
-
 ## Death Squad
 
 - type: entity
@@ -36,13 +28,12 @@
       nameSegments:
         - NamesMilitaryFirstLeader
         - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: RandomHumanoidSpawner
       settings: DeathSquad
 
 - type: randomHumanoidSettings
   id: DeathSquad
-  parent: EventHumanoidCentcomm
+  parent: EventHumanoidMindShielded
   randomizeName: false
   # Exodus-CentCom-Balance-and-Lore-Start
   speciesBlacklist:
@@ -75,7 +66,6 @@
       nameSegments:
         - NamesMilitaryFirstLeader
         - NamesMilitaryLast
-      nameFormat: name-format-ert
 
 
 ## ERT Leader
@@ -92,21 +82,18 @@
       nameSegments:
       - NamesMilitaryFirstLeader
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: RandomHumanoidSpawner
       settings: ERTLeader
 
 - type: randomHumanoidSettings
   id: ERTLeader
-  parent: EventHumanoidCentcomm
+  parent: EventHumanoidMindShielded
   randomizeName: false
   # Exodus-CentCom-Balance-and-Lore-Start
   speciesBlacklist:
     - Vox
     - Felinid
   # Exodus-CentCom-Balance-and-Lore-End
-  speciesBlacklist: # Exodus-MRP
-    - Vox
   components:
     - type: GhostRole
       name: ghost-role-information-ert-leader-name
@@ -122,7 +109,6 @@
       nameSegments:
       - NamesMilitaryFirstLeader
       - NamesMilitaryLast
-      nameFormat: name-format-ert
 
 - type: entity
   id: RandomHumanoidSpawnerERTLeaderEVA
@@ -189,7 +175,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: RandomHumanoidSpawner
       settings: ERTChaplain
 
@@ -209,7 +194,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: Loadout
       prototypes: [ ERTChaplainGear ]
       roleLoadout: [ RoleSurvivalExtended ]
@@ -257,7 +241,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: RandomHumanoidSpawner
       settings: ERTJanitor
 
@@ -276,7 +259,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: Loadout
       prototypes: [ ERTJanitorGear ]
       roleLoadout: [ RoleSurvivalExtended ]
@@ -323,7 +305,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: RandomHumanoidSpawner
       settings: ERTEngineer
 
@@ -342,7 +323,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: Loadout
       prototypes: [ ERTEngineerGear ]
       roleLoadout: [ RoleSurvivalExtended ]
@@ -389,7 +369,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: RandomHumanoidSpawner
       settings: ERTSecurity
 
@@ -408,7 +387,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: Loadout
       prototypes: [ ERTSecurityGear ]
       roleLoadout: [ RoleSurvivalExtended ]
@@ -478,7 +456,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: RandomHumanoidSpawner
       settings: ERTMedical
 
@@ -497,7 +474,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
     - type: Loadout
       prototypes: [ ERTMedicalGear ]
       roleLoadout: [ RoleSurvivalExtended ]
@@ -549,7 +525,7 @@
     - Felinid
   # Exodus-CentCom-Balance-and-Lore-End
   id: CBURNAgent
-  parent: EventHumanoidCentcomm
+  parent: EventHumanoidMindShielded
   components:
     - type: Loadout
       prototypes: [CBURNGear]
@@ -564,7 +540,6 @@
       nameSegments:
       - NamesMilitaryFirst
       - NamesMilitaryLast
-      nameFormat: name-format-ert
 
 ## Central Command
 
@@ -608,8 +583,6 @@
 
 - type: randomHumanoidSettings
   id: SyndicateAgent
-  speciesBlacklist: # Exodus-MRP
-    - Vox
   components:
     - type: RandomHumanoidAppearance
       randomizeName: false
@@ -653,7 +626,6 @@
       nameSegments:
       - NamesFirst
       - NamesLast
-      nameFormat: name-format-standard
 
 - type: randomHumanoidSettings
   id: Cluwne

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -580,9 +580,7 @@
 
 - type: randomHumanoidSettings
   id: CentcomOfficial
-  parent: EventHumanoidCentcomm
-  speciesBlacklist: # Exodus-MRP
-    - Vox
+  parent: EventHumanoidMindShielded
   components:
     - type: GhostRole
       name: ghost-role-information-centcom-official-name

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -44,7 +44,21 @@
   id: DeathSquad
   parent: EventHumanoidCentcomm
   randomizeName: false
-  speciesBlacklist: ['Diona'] # Corvax-MRP
+  # Exodus-CentCom-Balance-and-Lore-Start
+  speciesBlacklist:
+    - Diona
+    - Arachnid
+    - Dwarf
+    - Moth
+    - Reptilian
+    - Skeleton
+    - SlimePerson
+    - Vulpkanin
+    - Vox
+    - Kidan
+    - Felinid
+    - NewKidan
+  # Exodus-CentCom-Balance-and-Lore-End
   components:
     - type: GhostRole
       name: ghost-role-information-Death-Squad-name
@@ -86,6 +100,11 @@
   id: ERTLeader
   parent: EventHumanoidCentcomm
   randomizeName: false
+  # Exodus-CentCom-Balance-and-Lore-Start
+  speciesBlacklist:
+    - Vox
+    - Felinid
+  # Exodus-CentCom-Balance-and-Lore-End
   speciesBlacklist: # Exodus-MRP
     - Vox
   components:
@@ -376,9 +395,6 @@
 
 - type: randomHumanoidSettings
   id: ERTSecurity
-  speciesBlacklist: # Corvax-MRP
-    - Diona
-    - Vox # Exodus-MRP
   parent: ERTLeader
   components:
     - type: GhostRole
@@ -527,9 +543,11 @@
       settings: CBURNAgent
 
 - type: randomHumanoidSettings
-  speciesBlacklist: # Corvax-MRP
-    - Diona
-    - Vox # Exodus-MRP
+  # Exodus-CentCom-Balance-and-Lore-Start
+  speciesBlacklist:
+    - Vox
+    - Felinid
+  # Exodus-CentCom-Balance-and-Lore-End
   id: CBURNAgent
   parent: EventHumanoidCentcomm
   components:
@@ -613,8 +631,11 @@
 
 - type: randomHumanoidSettings
   id: NukeOp
-  speciesBlacklist: # Exodus-MRP
+  # Exodus-Nukie-Balance-and-Lore-Start
+  speciesBlacklist:
     - Vox
+    - Felinid
+  # Exodus-Nukie-Balance-and-Lore-End
   components:
     - type: RandomHumanoidAppearance
       randomizeName: false

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -107,7 +107,10 @@
     #Species that do not work with nukies should be included in this list.
     #Once the issues are fixed the species should be removed from this list to be enabled.
     #Balance concerns are not a valid reason to disable a species, except for high-impact Nukie-specific exploits.
-    #- Vox
+    # Exodus-Nukie-Balance-and-Lore-Start
+    - Vox
+    - Felinid
+    # Exodus-Nukie-Balance-and-Lore-End
 
 - type: entity
   parent: BaseNukeopsRule


### PR DESCRIPTION
## Описание PR
Теперь воксы и фелениды не могут быть среди ЯО (как спавнер так и раундстарт) и ОБР, также у Эскадрона Смерти могут быть только люди (касается спавнера оффов).

## Почему / Баланс
воксы не могут быть лорны в подобных штуках, фелениды геймплейно. 

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Space Exodus CLA](https://github.com/space-exodus/space-station-14/blob/master/CLA.txt) и соглашаюсь с её условиями.

**Список изменений**
:cl:
- tweak: Теперь воксы и фелениды не могут быть среди ЯО (как спавнер так и раундстарт) и ОБР, также у Эскадрона Смерти могут быть только люди (касается спавнера оффов).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
	- Обновлены ограничения по видам для специальных ролей: расширен список запрещённых видов для некоторых игровых ролей (DeathSquad, ERTLeader, CBURNAgent, CentcomOfficial, NukeOp).
- **Баланс**
	- Внесены изменения в список запрещённых видов для роли нюкеров: Felinid и Vox теперь исключены из выбора для этой роли.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->