### PR TITLE
Reduce light bulb damage

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -130,7 +130,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -154,7 +154,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 #LED lights
@@ -231,7 +231,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -348,7 +348,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -411,7 +411,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -428,7 +428,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 #Emergency Lights
@@ -521,7 +521,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -550,7 +550,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -579,7 +579,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -608,7 +608,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -637,7 +637,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -667,7 +667,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -696,7 +696,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -725,7 +725,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -130,7 +130,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -154,7 +154,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 #LED lights
@@ -174,7 +174,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 1 # LEDs don't get as hot
+        Heat: 0.01 # LEDs don't get as hot
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -200,7 +200,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 4 # brighter light gets hotter
+        Heat: 0.04 # brighter light gets hotter
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -231,7 +231,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -348,7 +348,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -369,7 +369,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 1
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -390,7 +390,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 1
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -411,7 +411,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -428,7 +428,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 #Emergency Lights
@@ -521,7 +521,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -550,7 +550,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -579,7 +579,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -608,7 +608,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -637,7 +637,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -667,7 +667,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -696,7 +696,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -725,7 +725,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -112,7 +112,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -137,7 +137,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -166,5 +166,5 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 1
+        Heat: 0.01
     popupText: powered-light-component-burn-hand

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -112,7 +112,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -137,7 +137,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
@@ -126,7 +126,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 0.02
     popupText: powered-light-component-burn-hand
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
@@ -126,7 +126,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.02
+        Heat: 0.01
     popupText: powered-light-component-burn-hand
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/service_light.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/service_light.yml
@@ -27,5 +27,5 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.05
+        Heat: 0.01
     popupText: powered-light-component-burn-hand

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/service_light.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/service_light.yml
@@ -27,5 +27,5 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 5
+        Heat: 0.05
     popupText: powered-light-component-burn-hand


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->

Лампочкам был порезан урон от троганья без перчаток до 0.01

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Space Exodus CLA](https://github.com/space-exodus/space-station-14/blob/master/CLA.txt) и соглашаюсь с её условиями.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Изменения баланса**
	- Значительно снижено количество урона от ожога при взаимодействии с различными типами осветительных приборов, включая уличные фонари, стробоскопы и сервисные светильники. Теперь урон минимален и практически не ощущается при контакте.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->