### PR TITLE
Grid roof remove

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -121,7 +121,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
             return;
 
         EnsureComp<ShuttleComponent>(ev.EntityUid);
-        EnsureComp<ImplicitRoofComponent>(ev.EntityUid);
+        // EnsureComp<ImplicitRoofComponent>(ev.EntityUid); Exodus-Roof-On-All-Grids-Remove
     }
 
     private void OnShuttleStartup(EntityUid uid, ShuttleComponent component, ComponentStartup args)


### PR DESCRIPTION
## Описание PR
Убрано автоматическое добавление крыши у любого грида.

## Почему / Баланс
С этим апстримом на любой грид автоматом накладывается крыша, что честно - руинит прикол многих планетарных карт, да и ивентовых в том числе. Так что мне кажется лучше сделать так.

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Space Exodus CLA](https://github.com/space-exodus/space-station-14/blob/master/CLA.txt) и соглашаюсь с её условиями.

**Список изменений**
:cl:
- remove: Убрано автоматическое добавление крыши у любого грида.

