### PR TITLE
Fix secrets validation in functions scripts

### DIFF
--- a/functions.bat
+++ b/functions.bat
@@ -9,7 +9,7 @@ if "%1" == "BuildComponent" (goto BuildComponent)
 :BuildComponent
 set component=%2
 
-if exist "%scriptDir%Secrets" (
+if exist "%scriptDir%Secrets\ExodusSecrets.sln" (
     set component=Secrets\%3
 )
 

--- a/functions.sh
+++ b/functions.sh
@@ -5,7 +5,7 @@ scriptDir="$(cd "$(dirname "$0")" && pwd)"
 build_component() {
     local component
 
-    if [ -d "$scriptDir/Secrets" ]; then
+    if [ -d "$scriptDir/Secrets/ExodusSecrets.sln" ]; then
         component="Secrets/$1"
     else
         component="$1"


### PR DESCRIPTION
## Описание PR
Исправлена проверка наличия секретов в скриптах запуска

## Технические детали
Раньше скрипты проверяли наличие папки, но её автоматически создаёт Git из-за наличия сабмодуля, несмотря на то, что по-умолчанию он в отключенном состоянии. Теперь скрипт смотрит на наличие ExodusSecrets.sln.

## Медиа
*Not Required*

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Space Exodus CLA](https://github.com/space-exodus/space-station-14/blob/master/CLA.txt) и соглашаюсь с её условиями.

## Критические изменения
*No Fun*

**Список изменений**
*No Fun*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Обновлены условия сборки компонентов для корректного определения наличия необходимых файлов в директории Secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->