### PR TITLE
Collision immune

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -56,6 +56,11 @@ namespace Content.Server.Shuttles.Components
         [ViewVariables]
         public DirectionFlag ThrustDirections = DirectionFlag.None;
 
+        // Exodus-Indestructible-Grid-Start
+        [DataField]
+        public bool CollisionImmunity = false;
+        // Exodus-Indestructible-Grid-End
+
         /// <summary>
         /// Base damping modifier applied to the shuttle's physics component when not in FTL.
         /// </summary>

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -141,8 +141,8 @@ public sealed partial class ShuttleSystem
 
             // Exodus-Indestructible-Grid-Start.
             // If one grid in case of collision have CollisionImmunity, both of them dont take damage.
-            if (!EntityManager.TryGetComponent<ShuttleComponent>(args.OtherEntity, out var otherComponent))
-                continue;
+            if (args.OtherEntity == null || !TryComp<ShuttleComponent>(args.OtherEntity, out var otherComponent))
+            continue;
 
             if (component.CollisionImmunity || otherComponent.CollisionImmunity)
                 continue;

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -139,6 +139,15 @@ public sealed partial class ShuttleSystem
                 continue;
             }
 
+            // Exodus-Indestructible-Grid-Start.
+            // If one grid in case of collision have CollisionImmunity, both of them dont take damage.
+            if (!EntityManager.TryGetComponent<ShuttleComponent>(args.OtherEntity, out var otherComponent))
+                continue;
+
+            if (component.CollisionImmunity || otherComponent.CollisionImmunity)
+                continue;
+            // Exodus-Indestructible-Grid-End
+
             // Play impact sound
             var coordinates = new EntityCoordinates(ourXform.MapUid.Value, worldPoint);
 


### PR DESCRIPTION
## Описание PR
Добавляет в игру параметр CollisionImmunity компонента Shuttle, который при выдаче его гриду не дает ни нанести ему урон при столкновении, ни получить его.

## Почему / Баланс
Это нужно для более гибкой настройки админам/мапперам гридов (если администратор условно захочет сделать так, что его грид на ивенте нельзя будет протаранить.

## Медиа

https://github.com/user-attachments/assets/2154a9ed-a250-4445-b399-b9359e4ff438

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
- [x] Я подтверждаю, что мои изменения находятся под лицензией [Space Exodus CLA](https://github.com/space-exodus/space-station-14/blob/master/CLA.txt) и соглашаюсь с её условиями.


**Список изменений**
:cl:
- add: Добавлен параметр CollisionImmunity компонента Shuttle, который при выдаче его гриду не дает ни нанести ему урон при столкновении, ни получить его.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Добавлена опция иммунитета к столкновениям для отдельных шаттлов/гридов.
  * При включённом иммунитете столкновения с участием такого шаттла не наносят урон и не запускают сопутствующие эффекты (звуки, тряска, визуальные импакты).
  * Иммунитет работает двусторонне: если хотя бы один участник защищён, последствия отключаются для всего инцидента.
  * Функция применяется только к столкновениям между шаттлами; обычное поведение сохранено.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->